### PR TITLE
Add correct relative path to use for macs to find .git project

### DIFF
--- a/pymdwizard/core/utils.py
+++ b/pymdwizard/core/utils.py
@@ -455,7 +455,7 @@ def get_install_dname(which='pymdwizard'):
     this_fname = os.path.realpath(__file__)
     if platform.system() == 'Darwin':
         # This is the path to the 'content' folder in the MetadataWizard.app
-        pymdwizard_dname = os.path.abspath(os.path.join(dirname(this_fname), *['..']*7))
+        pymdwizard_dname = os.path.abspath(os.path.join(dirname(this_fname), *['..']*2))
         root_dir = pymdwizard_dname
         executable = sys.executable
         python_dname = os.path.split(executable)[0]


### PR DESCRIPTION
Allows Darwin systems (macs) to access the location of the .git project for git updates.